### PR TITLE
Add index page

### DIFF
--- a/receiver_web.go
+++ b/receiver_web.go
@@ -70,6 +70,7 @@ func (w *webReceiver) inbox() chan serializer {
 
 func (w *webReceiver) start() {
 	go func() {
+		l.Printf("Starting Web server at :%d.", w.port)
 		srv := &http.Server{
 			Addr:    fmt.Sprintf(":%d", w.port),
 			Handler: w.router,

--- a/receiver_web.go
+++ b/receiver_web.go
@@ -15,6 +15,7 @@ const (
 	// https://developer.fastly.com/reference/http/http-headers/Fastly-Client-IP/
 	// (retrieved on 2021-11-29)
 	fastlyClientIP = "Fastly-Client-IP"
+	indexPage      = "This request is handled by tokenizer."
 )
 
 var (
@@ -55,6 +56,7 @@ func newWebReceiver() receiver {
 func newRouter(inbox chan serializer) *chi.Mux {
 	r := chi.NewRouter()
 	r.Get("/v2/confirmation/token/{walletID}", getConfTokenHandler(inbox))
+	r.Get("/", indexHandler)
 	return r
 }
 
@@ -78,6 +80,10 @@ func (w *webReceiver) start() {
 
 func (w *webReceiver) stop() {
 	close(w.done)
+}
+
+func indexHandler(w http.ResponseWriter, r *http.Request) {
+	fmt.Fprint(w, indexPage)
 }
 
 func getConfTokenHandler(inbox chan serializer) http.HandlerFunc {

--- a/receiver_web.go
+++ b/receiver_web.go
@@ -84,7 +84,7 @@ func (w *webReceiver) stop() {
 }
 
 func indexHandler(w http.ResponseWriter, r *http.Request) {
-	fmt.Fprint(w, indexPage)
+	fmt.Fprintln(w, indexPage)
 }
 
 func getConfTokenHandler(inbox chan serializer) http.HandlerFunc {

--- a/receiver_web_test.go
+++ b/receiver_web_test.go
@@ -38,7 +38,7 @@ func TestIndexRequest(t *testing.T) {
 		t.Fatalf("Expected HTTP status code %d but got %d.", http.StatusOK, resp.StatusCode)
 	}
 	body, _ := io.ReadAll(resp.Body)
-	if string(body) != indexPage {
+	if strings.TrimSpace(string(body)) != indexPage {
 		t.Fatalf("Expected body %q but got %q.", indexPage, string(body))
 	}
 }

--- a/receiver_web_test.go
+++ b/receiver_web_test.go
@@ -28,6 +28,21 @@ func makeReq(t *testing.T, s *httptest.Server, method, path string, h http.Heade
 	return resp
 }
 
+func TestIndexRequest(t *testing.T) {
+	inbox := make(chan serializer, 10) // We're using a buffered channel to prevent a deadlock.
+	srv := httptest.NewServer(newRouter(inbox))
+	defer srv.Close()
+
+	resp := makeReq(t, srv, http.MethodGet, "/", nil)
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("Expected HTTP status code %d but got %d.", http.StatusOK, resp.StatusCode)
+	}
+	body, _ := io.ReadAll(resp.Body)
+	if string(body) != indexPage {
+		t.Fatalf("Expected body %q but got %q.", indexPage, string(body))
+	}
+}
+
 func TestGoodRequest(t *testing.T) {
 	walletID := newV4(t)
 	expected := clientRequest{


### PR DESCRIPTION
This PR adds an index page to tokenizer's Web receiver, which helps with testing.