### PR TITLE
Support ads API version 1, 2, 3, and 4.

### DIFF
--- a/receiver_web_test.go
+++ b/receiver_web_test.go
@@ -120,3 +120,17 @@ func TestBadFastlyAddr(t *testing.T) {
 		t.Fatalf("Expected error %q but got %q.", expected, received)
 	}
 }
+
+func TestIsValidApiVersion(t *testing.T) {
+	assertEqual(t, isValidApiVersion("1"), true)
+	assertEqual(t, isValidApiVersion("2"), true)
+	assertEqual(t, isValidApiVersion("3"), true)
+	assertEqual(t, isValidApiVersion("4"), true)
+
+	assertEqual(t, isValidApiVersion("0"), false)
+	assertEqual(t, isValidApiVersion("5"), false)
+	assertEqual(t, isValidApiVersion("99"), false)
+	assertEqual(t, isValidApiVersion("-1"), false)
+	assertEqual(t, isValidApiVersion("1.1"), false)
+	assertEqual(t, isValidApiVersion("foo"), false)
+}


### PR DESCRIPTION
This commit makes tokenizer support ads API version 1 to 4.  Note that version 4 is not yet in the works but we support it regardless, to be future-proof.

This fixes issue https://github.com/brave/tokenizer/issues/23.