### PR TITLE
Disable reproducible build.

### DIFF
--- a/.github/workflows/generalized-deployments-reproducible.yaml
+++ b/.github/workflows/generalized-deployments-reproducible.yaml
@@ -17,7 +17,5 @@ jobs:
     - name: Override GITHUB_REF and thus ECR destination for master
       run: echo "GITHUB_REF_OVERRIDE=refs/heads/dev" >> $GITHUB_ENV
       if: ${{ github.ref == 'refs/heads/master' }}
-    - name: Set REPRODUCIBLE to get a reproducible build
-      run: echo "REPRODUCIBLE=true" >> $GITHUB_ENV
     - name: Generalized Deployments
       uses: brave-intl/general-docker-build-pipeline-action@v1.0.9


### PR DESCRIPTION
Reproducible builds strip metadata that flux relies on to auto-deploy images in Kubernetes.  This commit disables reproducible builds. Tokenizer does not run in an enclave (for now), so there's no need for it.