### PR TITLE
Fix production issues.

### DIFF
--- a/forwarder_kafka.go
+++ b/forwarder_kafka.go
@@ -168,12 +168,12 @@ func (k *kafkaForwarder) send(t token) error {
 	err := k.writer.WriteMessages(context.Background(), k.msgBatch...)
 	if err != nil {
 		err := fmt.Errorf("failed to forward blob to Kafka: %w", err)
-		m.numForwarded.With(prometheus.Labels{outcome: failBecause(err)}).Inc()
+		m.numForwarded.With(prometheus.Labels{outcome: failBecause(err)}).Add(float64(len(k.msgBatch)))
 		return err
 	}
 	l.Printf("Sent %d tokens to Kafka.", len(k.msgBatch))
 	k.resetBatch()
-	m.numForwarded.With(prometheus.Labels{outcome: success}).Inc()
+	m.numForwarded.With(prometheus.Labels{outcome: success}).Add(float64(len(k.msgBatch)))
 	return nil
 }
 

--- a/forwarder_kafka.go
+++ b/forwarder_kafka.go
@@ -10,12 +10,15 @@ import (
 	"os"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/segmentio/kafka-go"
 )
 
 const (
+	defaultBatchPeriod = time.Second * 30
+	defaultBatchSize   = 1000
 	envKafkaClientCert = "KAFKA_CLIENT_CERT"
 	envKafkaClientKey  = "KAFKA_CLIENT_KEY"
 	envKafkaInterCert  = "KAFKA_INTERMEDIATE_CERT"
@@ -59,7 +62,16 @@ var (
 	errNothingToFwd = errors.New("nothing to forward")
 )
 
+// kafkaWriter defines an interface that's implemented by kafka-go's
+// kafka.Writer (which we use in production) and by dummyKafkaWriter (which we
+// use for tests).
+type kafkaWriter interface {
+	WriteMessages(ctx context.Context, msgs ...kafka.Message) error
+}
+
 type kafkaConfig struct {
+	batchPeriod time.Duration
+	batchSize   int
 	clientCert  *tls.Certificate
 	serverCerts *x509.CertPool
 	broker      net.Addr
@@ -70,16 +82,20 @@ type kafkaConfig struct {
 // broker.
 type kafkaForwarder struct {
 	sync.RWMutex
-	conf   *kafkaConfig
-	writer *kafka.Writer
-	out    chan token
-	done   chan empty
+	msgBatch  []kafka.Message
+	lastBatch time.Time
+	conf      *kafkaConfig
+	writer    kafkaWriter
+	out       chan token
+	done      chan empty
 }
 
 func newKafkaForwarder() forwarder {
 	return &kafkaForwarder{
-		out:  make(chan token),
-		done: make(chan empty),
+		msgBatch:  []kafka.Message{},
+		lastBatch: time.Now(),
+		out:       make(chan token),
+		done:      make(chan empty),
 	}
 }
 
@@ -117,6 +133,19 @@ func (k *kafkaForwarder) stop() {
 	close(k.done)
 }
 
+func (k *kafkaForwarder) canBatchAge() bool {
+	return time.Now().Add(-k.conf.batchPeriod).Before(k.lastBatch)
+}
+
+func (k *kafkaForwarder) canBatchGrow() bool {
+	return len(k.msgBatch) < k.conf.batchSize
+}
+
+func (k *kafkaForwarder) resetBatch() {
+	k.lastBatch = time.Now()
+	k.msgBatch = []kafka.Message{}
+}
+
 func (k *kafkaForwarder) send(t token) error {
 	k.Lock()
 	defer k.Unlock()
@@ -126,18 +155,24 @@ func (k *kafkaForwarder) send(t token) error {
 		return errNothingToFwd
 	}
 
-	err := k.writer.WriteMessages(context.Background(),
-		kafka.Message{
+	// We batch messages until 1) the batch gets too large or 2) the batch gets
+	// too old -- whichever comes first.
+	if k.canBatchAge() && k.canBatchGrow() {
+		k.msgBatch = append(k.msgBatch, kafka.Message{
 			Key:   nil,
 			Value: t,
-		},
-	)
+		})
+		return nil
+	}
+
+	err := k.writer.WriteMessages(context.Background(), k.msgBatch...)
 	if err != nil {
 		err := fmt.Errorf("failed to forward blob to Kafka: %w", err)
 		m.numForwarded.With(prometheus.Labels{outcome: failBecause(err)}).Inc()
 		return err
 	}
-	l.Printf("Sent %d-byte token to Kafka.", len(t))
+	l.Printf("Sent %d tokens to Kafka.", len(k.msgBatch))
+	k.resetBatch()
 	m.numForwarded.With(prometheus.Labels{outcome: success}).Inc()
 	return nil
 }
@@ -248,6 +283,8 @@ func loadKafkaConfig() (*kafkaConfig, error) {
 
 	l.Println("Loaded Kafka config.")
 	return &kafkaConfig{
+		batchSize:   defaultBatchSize,
+		batchPeriod: defaultBatchPeriod,
 		clientCert:  clientCert,
 		serverCerts: serverCerts,
 		broker:      kafka.TCP(broker),

--- a/main.go
+++ b/main.go
@@ -194,5 +194,8 @@ func main() {
 	if conf.exposePrometheus {
 		go exposeMetrics(conf.prometheusPort)
 	}
+	if err := maxSoftFdLimit(); err != nil {
+		l.Printf("Failed to maximize soft fd limit: %v", err)
+	}
 	bootstrap(conf, comp, make(chan empty))
 }

--- a/util.go
+++ b/util.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	"syscall"
+
 	"github.com/linkedin/goavro/v2"
 )
 
@@ -11,4 +13,24 @@ func avroEncode(codec *goavro.Codec, blob []byte) ([]byte, error) {
 	}
 	binary, err := codec.BinaryFromNative(nil, native)
 	return binary, err
+}
+
+// maxSoftFdLimit raises the file descriptor soft limit to the hard limit.
+func maxSoftFdLimit() error {
+	var rLimit = new(syscall.Rlimit)
+	if err := syscall.Getrlimit(syscall.RLIMIT_NOFILE, rLimit); err != nil {
+		return err
+	}
+	l.Printf("Original fd limit: cur=%d, max=%d", rLimit.Cur, rLimit.Max)
+
+	rLimit.Cur = rLimit.Max
+	if err := syscall.Setrlimit(syscall.RLIMIT_NOFILE, rLimit); err != nil {
+		return err
+	}
+	if err := syscall.Getrlimit(syscall.RLIMIT_NOFILE, rLimit); err != nil {
+		return err
+	}
+	l.Printf("Modified fd limit: cur=%d, max=%d.", rLimit.Cur, rLimit.Max)
+
+	return nil
 }

--- a/util_test.go
+++ b/util_test.go
@@ -43,3 +43,7 @@ func TestAvroEncode(t *testing.T) {
 		t.Fatalf("Expected\n%v\nbut got\n%v", origStruct, decodedStruct)
 	}
 }
+
+func TestMaxSoftFdLimit(t *testing.T) {
+	assertEqual(t, maxSoftFdLimit(), nil)
+}


### PR DESCRIPTION
This PR addresses issues that surfaced in our production deployment:

1. Tokenizer runs out of file descriptors, resulting in the refusal to accept new connections.
2. We send one token at a time to Kafka, which comes with way too much overhead.

We address these problems by raising the soft fd limit to the hard limit, and by implementing a batching mechanism.