### PR TITLE
Use latest build pipeline action.

### DIFF
--- a/.github/workflows/generalized-deployments-reproducible.yaml
+++ b/.github/workflows/generalized-deployments-reproducible.yaml
@@ -18,4 +18,4 @@ jobs:
       run: echo "GITHUB_REF_OVERRIDE=refs/heads/dev" >> $GITHUB_ENV
       if: ${{ github.ref == 'refs/heads/master' }}
     - name: Generalized Deployments
-      uses: brave-intl/general-docker-build-pipeline-action@v1
+      uses: brave-intl/general-docker-build-pipeline-action@v1.0.11


### PR DESCRIPTION
This eases deployment because the latest action displays the image ID in the workflow summary.