### PR TITLE
Move defer statement to the correct place.

### DIFF
--- a/forwarder_kafka.go
+++ b/forwarder_kafka.go
@@ -112,9 +112,8 @@ func (k *kafkaForwarder) start() {
 	k.Unlock()
 
 	k.tokenCache.start()
-	defer k.tokenCache.stop()
-
 	go func() {
+		defer k.tokenCache.stop()
 		for {
 			select {
 			case <-k.done:


### PR DESCRIPTION
The start function returns right away, triggering the defer, which stops the token cache.  This results in the Kafka forwarder blocking.